### PR TITLE
Support for Castlabs DRMToday

### DIFF
--- a/src/castlabs/CastLabsDrmConfiguration.ts
+++ b/src/castlabs/CastLabsDrmConfiguration.ts
@@ -1,0 +1,30 @@
+import type { DRMConfiguration } from 'react-native-theoplayer';
+import type { CastLabsIntegrationParameters } from './CastLabsIntegrationParameters';
+
+/**
+ * The identifier of the CastLabs integration.
+ */
+export type CastLabsDrmIntegrationID = 'castlabs';
+
+/**
+ * Describes the configuration of the CastLabs DRM integration.
+ *
+ * ```
+ * const drmConfiguration = {
+ *      integration : 'castlabs',
+ *      fairplay: {
+ *          certificateURL: 'yourCertificateUrl',
+ *          licenseAcquisitionURL: 'yourLicenseAcquisitionURL'
+ *      }
+ * }
+ * ```
+ */
+export interface CastLabsDrmConfiguration extends DRMConfiguration {
+  /**
+   * The identifier of the DRM integration.
+   */
+  integration: CastLabsDrmIntegrationID;
+
+  integrationParameters: CastLabsIntegrationParameters;
+}
+

--- a/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
@@ -48,7 +48,6 @@ export class CastLabsFairplayContentProtectionIntegration implements ContentProt
     if ('<ckc>' === license.substr(0, 5) && '</ckc>' === license.substr(-6)) {
       license = license.slice(5, -6);
     }
-    console.log(license);
     return fromBase64StringToUint8Array(license);
   }
 

--- a/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
@@ -3,7 +3,7 @@ import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
 import { fromObjectToBase64String, fromUint8ArrayToBase64String, fromStringToUint8Array, fromUint8ArrayToString, fromBase64StringToUint8Array } from 'react-native-theoplayer';
 
 export class CastLabsFairplayContentProtectionIntegration implements ContentProtectionIntegration {
-  static readonly DEFAULT_CERTIFICATE_URL = 'https://lic.staging.drmtoday.com/license-server-fairplay/cert/pathehome';
+  static readonly DEFAULT_CERTIFICATE_URL = 'insert default certificate url here';
   static readonly DEFAULT_LICENSE_URL = 'insert default license url here';
 
   private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;

--- a/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
@@ -1,0 +1,59 @@
+import type { CertificateRequest, ContentProtectionIntegration, LicenseRequest, LicenseResponse, MaybeAsync } from 'react-native-theoplayer';
+import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
+import { fromObjectToBase64String, fromUint8ArrayToBase64String, fromStringToUint8Array, fromUint8ArrayToString, fromBase64StringToUint8Array } from 'react-native-theoplayer';
+
+export class CastLabsFairplayContentProtectionIntegration implements ContentProtectionIntegration {
+  static readonly DEFAULT_CERTIFICATE_URL = 'https://lic.staging.drmtoday.com/license-server-fairplay/cert/pathehome';
+  static readonly DEFAULT_LICENSE_URL = 'insert default license url here';
+
+  private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;
+  private contentId: string | undefined = undefined;
+  private customData: string;
+
+  constructor(configuration: CastLabsDrmConfiguration) {
+    this.contentProtectionConfiguration = configuration;
+    const customDataObject = {
+      userId: this.contentProtectionConfiguration.integrationParameters.userId,
+      sessionId: this.contentProtectionConfiguration.integrationParameters.sessionId,
+      merchant: this.contentProtectionConfiguration.integrationParameters.merchant
+    };
+    this.customData = fromObjectToBase64String(customDataObject);
+  }
+
+  onCertificateRequest(request: CertificateRequest): MaybeAsync<Partial<CertificateRequest> | BufferSource> {
+    request.url = this.contentProtectionConfiguration.fairplay?.certificateURL ?? CastLabsFairplayContentProtectionIntegration.DEFAULT_CERTIFICATE_URL;
+    request.headers = {
+      ...request.headers,
+    };
+    return request;
+  }
+
+  onLicenseRequest(request: LicenseRequest): MaybeAsync<Partial<LicenseRequest> | BufferSource> {
+    request.url =
+      this.contentProtectionConfiguration.fairplay?.licenseAcquisitionURL ?? CastLabsFairplayContentProtectionIntegration.DEFAULT_LICENSE_URL;
+    request.headers = {
+      ...request.headers,
+      'x-dt-custom-data': this.customData!,
+      'x-dt-auth-token': this.contentProtectionConfiguration.integrationParameters.token ?? '',
+      'content-type': 'application/x-www-form-urlencoded',
+    };
+    const body = `spc=${encodeURIComponent(fromUint8ArrayToBase64String(request.body!))}&${encodeURIComponent(this.contentId!)}`;
+    request.body = fromStringToUint8Array(body);
+
+    return request;
+  }
+
+  onLicenseResponse?(response: LicenseResponse): MaybeAsync<BufferSource> {
+    let license = fromUint8ArrayToString(response.body);
+    if ('<ckc>' === license.substr(0, 5) && '</ckc>' === license.substr(-6)) {
+      license = license.slice(5, -6);
+    }
+    console.log(license);
+    return fromBase64StringToUint8Array(license);
+  }
+
+  extractFairplayContentId(skdUrl: string): string {
+    this.contentId = skdUrl
+    return this.contentId;
+  }
+}

--- a/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsFairplayContentProtectionIntegration.ts
@@ -3,8 +3,8 @@ import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
 import { fromObjectToBase64String, fromUint8ArrayToBase64String, fromStringToUint8Array, fromUint8ArrayToString, fromBase64StringToUint8Array } from 'react-native-theoplayer';
 
 export class CastLabsFairplayContentProtectionIntegration implements ContentProtectionIntegration {
-  static readonly DEFAULT_CERTIFICATE_URL = 'insert default certificate url here';
-  static readonly DEFAULT_LICENSE_URL = 'insert default license url here';
+  static readonly DEFAULT_CERTIFICATE_URL = 'https://lic.drmtoday.com/license-server-fairplay/cert/';
+  static readonly DEFAULT_LICENSE_URL = 'https://lic.staging.drmtoday.com/license-server-fairplay/cert/';
 
   private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;
   private contentId: string | undefined = undefined;

--- a/src/castlabs/CastLabsFairplayContentProtectionIntegrationFactory.ts
+++ b/src/castlabs/CastLabsFairplayContentProtectionIntegrationFactory.ts
@@ -1,0 +1,9 @@
+import type { ContentProtectionIntegration, ContentProtectionIntegrationFactory } from 'react-native-theoplayer';
+import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
+import { CastLabsFairplayContentProtectionIntegration } from './CastLabsFairplayContentProtectionIntegration';
+
+export class CastLabsFairplayContentProtectionIntegrationFactory implements ContentProtectionIntegrationFactory {
+  build(configuration: CastLabsDrmConfiguration): ContentProtectionIntegration {
+    return new CastLabsFairplayContentProtectionIntegration(configuration);
+  }
+}

--- a/src/castlabs/CastLabsIntegrationParameters.ts
+++ b/src/castlabs/CastLabsIntegrationParameters.ts
@@ -1,0 +1,29 @@
+export interface CastLabsIntegrationParameters {
+  /**
+   * The CastLabs token
+   *
+   */
+  token?: string;
+
+  /**
+   * The CastLabs merchant
+   *
+   *
+   */
+  merchant?: string;
+
+  /**
+   * The CastLabs sessionId
+   *
+   *
+   */
+  sessionId?: string;
+
+  /**
+   * The CastLabs userId
+   *
+   *
+   */
+  userId?: string;
+
+}

--- a/src/castlabs/CastLabsPlayReadyContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsPlayReadyContentProtectionIntegration.ts
@@ -3,6 +3,8 @@ import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
 import { fromObjectToBase64String } from 'react-native-theoplayer';
 
 export class CastLabsPlayReadyContentProtectionIntegration implements ContentProtectionIntegration {
+  static readonly DEFAULT_LICENSE_URL = 'https://lic.drmtoday.com/license-proxy-headerauth/drmtoday/RightsManager.asmx';
+
   private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;
   private customData: string;
 
@@ -17,6 +19,7 @@ export class CastLabsPlayReadyContentProtectionIntegration implements ContentPro
   }
 
   onLicenseRequest(request: LicenseRequest): MaybeAsync<Partial<LicenseRequest> | BufferSource> {
+    request.url = this.contentProtectionConfiguration.playready?.licenseAcquisitionURL ?? CastLabsPlayReadyContentProtectionIntegration.DEFAULT_LICENSE_URL;
     request.headers = {
       ...request.headers,
       'x-dt-custom-data': this.customData!,

--- a/src/castlabs/CastLabsPlayReadyContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsPlayReadyContentProtectionIntegration.ts
@@ -1,0 +1,27 @@
+import type { ContentProtectionIntegration, LicenseRequest, MaybeAsync } from 'react-native-theoplayer';
+import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
+import { fromObjectToBase64String } from 'react-native-theoplayer';
+
+export class CastLabsPlayReadyContentProtectionIntegration implements ContentProtectionIntegration {
+  private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;
+  private customData: string;
+
+  constructor(configuration: CastLabsDrmConfiguration) {
+    this.contentProtectionConfiguration = configuration;
+    const customDataObject = {
+      userId: this.contentProtectionConfiguration.integrationParameters.userId,
+      sessionId: this.contentProtectionConfiguration.integrationParameters.sessionId,
+      merchant: this.contentProtectionConfiguration.integrationParameters.merchant
+    };
+    this.customData = fromObjectToBase64String(customDataObject);
+  }
+
+  onLicenseRequest(request: LicenseRequest): MaybeAsync<Partial<LicenseRequest> | BufferSource> {
+    request.headers = {
+      ...request.headers,
+      'x-dt-custom-data': this.customData!,
+      'x-dt-auth-token': this.contentProtectionConfiguration.integrationParameters.token ?? '',
+    };
+    return request;
+  }
+}

--- a/src/castlabs/CastLabsPlayReadyContentProtectionIntegrationFactory.ts
+++ b/src/castlabs/CastLabsPlayReadyContentProtectionIntegrationFactory.ts
@@ -1,0 +1,9 @@
+import type { ContentProtectionIntegration, ContentProtectionIntegrationFactory } from 'react-native-theoplayer';
+import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
+import { CastLabsPlayReadyContentProtectionIntegration } from './CastLabsPlayReadyContentProtectionIntegration';
+
+export class CastLabsPlayReadyContentProtectionIntegrationFactory implements ContentProtectionIntegrationFactory {
+  build(configuration: CastLabsDrmConfiguration): ContentProtectionIntegration {
+    return new CastLabsPlayReadyContentProtectionIntegration(configuration);
+  }
+}

--- a/src/castlabs/CastLabsWidevineContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsWidevineContentProtectionIntegration.ts
@@ -3,6 +3,8 @@ import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
 import { fromObjectToBase64String } from 'react-native-theoplayer';
 
 export class CastLabsWidevineContentProtectionIntegration implements ContentProtectionIntegration {
+  static readonly DEFAULT_LICENSE_URL = 'https://lic.drmtoday.com/license-proxy-widevine/cenc/';
+
   private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;
   private customData: string;
 
@@ -17,6 +19,10 @@ export class CastLabsWidevineContentProtectionIntegration implements ContentProt
   }
 
   onLicenseRequest(request: LicenseRequest): MaybeAsync<Partial<LicenseRequest> | BufferSource> {
+    // DRMToday has the option to return licences as binary data by using ?specConform=true, however we expect JSON so remove url params from licenseUrl
+    let licenseUrl = new URL(this.contentProtectionConfiguration.widevine?.licenseAcquisitionURL ?? CastLabsWidevineContentProtectionIntegration.DEFAULT_LICENSE_URL);
+    request.url = licenseUrl.protocol + "//" + licenseUrl.host + licenseUrl.pathname;
+
     request.headers = {
       ...request.headers,
       'x-dt-custom-data': this.customData!,

--- a/src/castlabs/CastLabsWidevineContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsWidevineContentProtectionIntegration.ts
@@ -1,6 +1,6 @@
-import type { ContentProtectionIntegration, LicenseRequest, MaybeAsync } from 'react-native-theoplayer';
+import type { ContentProtectionIntegration, LicenseRequest, LicenseResponse, MaybeAsync } from 'react-native-theoplayer';
 import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
-import { fromObjectToBase64String } from 'react-native-theoplayer';
+import { fromObjectToBase64String, fromUint8ArrayToString, fromBase64StringToUint8Array } from 'react-native-theoplayer';
 
 export class CastLabsWidevineContentProtectionIntegration implements ContentProtectionIntegration {
   static readonly DEFAULT_LICENSE_URL = 'https://lic.drmtoday.com/license-proxy-widevine/cenc/';
@@ -19,15 +19,20 @@ export class CastLabsWidevineContentProtectionIntegration implements ContentProt
   }
 
   onLicenseRequest(request: LicenseRequest): MaybeAsync<Partial<LicenseRequest> | BufferSource> {
-    // DRMToday has the option to return licences as binary data by using ?specConform=true, however we expect JSON so remove url params from licenseUrl
-    let licenseUrl = new URL(this.contentProtectionConfiguration.widevine?.licenseAcquisitionURL ?? CastLabsWidevineContentProtectionIntegration.DEFAULT_LICENSE_URL);
-    request.url = licenseUrl.protocol + "//" + licenseUrl.host + licenseUrl.pathname;
-
+    request.url = (this.contentProtectionConfiguration.widevine?.licenseAcquisitionURL ?? CastLabsWidevineContentProtectionIntegration.DEFAULT_LICENSE_URL).replace("?specConform=true","");
     request.headers = {
       ...request.headers,
       'x-dt-custom-data': this.customData!,
       'x-dt-auth-token': this.contentProtectionConfiguration.integrationParameters.token ?? '',
     };
+
     return request;
+  }
+
+  onLicenseResponse?(response: LicenseResponse): MaybeAsync<BufferSource> {
+    const responseAsText = fromUint8ArrayToString(response.body);
+    const responseObject = JSON.parse(responseAsText);
+
+    return fromBase64StringToUint8Array(responseObject.license);
   }
 }

--- a/src/castlabs/CastLabsWidevineContentProtectionIntegration.ts
+++ b/src/castlabs/CastLabsWidevineContentProtectionIntegration.ts
@@ -1,0 +1,27 @@
+import type { ContentProtectionIntegration, LicenseRequest, MaybeAsync } from 'react-native-theoplayer';
+import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
+import { fromObjectToBase64String } from 'react-native-theoplayer';
+
+export class CastLabsWidevineContentProtectionIntegration implements ContentProtectionIntegration {
+  private readonly contentProtectionConfiguration: CastLabsDrmConfiguration;
+  private customData: string;
+
+  constructor(configuration: CastLabsDrmConfiguration) {
+    this.contentProtectionConfiguration = configuration;
+    const customDataObject = {
+      userId: this.contentProtectionConfiguration.integrationParameters.userId,
+      sessionId: this.contentProtectionConfiguration.integrationParameters.sessionId,
+      merchant: this.contentProtectionConfiguration.integrationParameters.merchant
+    };
+    this.customData = fromObjectToBase64String(customDataObject);
+  }
+
+  onLicenseRequest(request: LicenseRequest): MaybeAsync<Partial<LicenseRequest> | BufferSource> {
+    request.headers = {
+      ...request.headers,
+      'x-dt-custom-data': this.customData!,
+      'x-dt-auth-token': this.contentProtectionConfiguration.integrationParameters.token ?? '',
+    };
+    return request;
+  }
+}

--- a/src/castlabs/CastLabsWidevineContentProtectionIntegrationFactory.ts
+++ b/src/castlabs/CastLabsWidevineContentProtectionIntegrationFactory.ts
@@ -1,0 +1,9 @@
+import type { ContentProtectionIntegration, ContentProtectionIntegrationFactory } from 'react-native-theoplayer';
+import type { CastLabsDrmConfiguration } from './CastLabsDrmConfiguration';
+import { CastLabsWidevineContentProtectionIntegration } from './CastLabsWidevineContentProtectionIntegration';
+
+export class CastLabsWidevineContentProtectionIntegrationFactory implements ContentProtectionIntegrationFactory {
+  build(configuration: CastLabsDrmConfiguration): ContentProtectionIntegration {
+    return new CastLabsWidevineContentProtectionIntegration(configuration);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ import {
 import {
   CastLabsFairplayContentProtectionIntegrationFactory,
 } from './castlabs/CastLabsFairplayContentProtectionIntegrationFactory';
+import {
+  CastLabsPlayReadyContentProtectionIntegrationFactory,
+} from './castlabs/CastLabsPlayReadyContentProtectionIntegrationFactory';
+import {
+  CastLabsWidevineContentProtectionIntegrationFactory,
+} from './castlabs/CastLabsWidevineContentProtectionIntegrationFactory';
 
 
 export {
@@ -29,4 +35,6 @@ export {
   VerimatrixCoreDrmPlayReadyContentProtectionIntegrationFactory,
   VerimatrixCoreDrmWidevineContentProtectionIntegrationFactory,
   CastLabsFairplayContentProtectionIntegrationFactory,
+  CastLabsPlayReadyContentProtectionIntegrationFactory,
+  CastLabsWidevineContentProtectionIntegrationFactory,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,10 @@ import {
 import {
   VerimatrixCoreDrmWidevineContentProtectionIntegrationFactory,
 } from './verimatrixcoredrm/VerimatrixCoreDrmWidevineContentProtectionIntegrationFactory';
+import {
+  CastLabsFairplayContentProtectionIntegrationFactory,
+} from './castlabs/CastLabsFairplayContentProtectionIntegrationFactory';
+
 
 export {
   AnvatoDrmFairplayContentProtectionIntegrationFactory,
@@ -24,4 +28,5 @@ export {
   VerimatrixCoreDrmFairplayContentProtectionIntegrationFactory,
   VerimatrixCoreDrmPlayReadyContentProtectionIntegrationFactory,
   VerimatrixCoreDrmWidevineContentProtectionIntegrationFactory,
+  CastLabsFairplayContentProtectionIntegrationFactory,
 };


### PR DESCRIPTION
We encountered issues when trying to use the existing DRMtoday preintegration: https://docs.theoplayer.com/how-to-guides/04-drm/02-castlabs-drmtoday/00-introduction.md withinour react-native project. After trying out various options to resolve the issue we came accross: https://github.com/THEOplayer/react-native-theoplayer-drm which didn't have a castlabs / drmtoday integration yet, so we haev written one based on our experience / the existing web connector