### PR TITLE
Make buydrm x-keyos-authorization optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Changed the BuyDRM KeyOS connector to work without the `x-keyos-authorization` header.
+
 ## [1.5.0] - 2024-04-12
 
 ### Added

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 THEOplayer
+Copyright (c) 2024 THEOplayer
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights

--- a/src/keyos/KeyOSDrmConfiguration.ts
+++ b/src/keyos/KeyOSDrmConfiguration.ts
@@ -18,7 +18,7 @@ export interface KeyOSDrmConfiguration extends DRMConfiguration {
    * An object of key/value pairs which can be used to pass in specific parameters related to a source into a
    * ContentProtectionIntegration.
    */
-  integrationParameters: {
+  integrationParameters?: {
     /**
      * The KeyOS BuyDRM Authorization Token.
      *

--- a/src/keyos/KeyOSDrmFairplayContentProtectionIntegration.ts
+++ b/src/keyos/KeyOSDrmFairplayContentProtectionIntegration.ts
@@ -19,7 +19,7 @@ export class KeyOSDrmFairplayContentProtectionIntegration implements ContentProt
 
   constructor(configuration: KeyOSDrmConfiguration) {
     if (!isKeyOSDrmDRMConfiguration(configuration)) {
-      throw new Error('The KeyOS customdata value has not been correctly configured.');
+      throw new Error('Invalid KeyOSDrmConfiguration.');
     }
     this.contentProtectionConfiguration = configuration;
   }

--- a/src/keyos/KeyOSDrmFairplayContentProtectionIntegration.ts
+++ b/src/keyos/KeyOSDrmFairplayContentProtectionIntegration.ts
@@ -29,10 +29,14 @@ export class KeyOSDrmFairplayContentProtectionIntegration implements ContentProt
       throw new Error('The KeyOS certificate url has not been correctly configured.');
     }
     request.url = this.contentProtectionConfiguration.fairplay?.certificateURL;
-    request.headers = {
-      ...request.headers,
-      'x-keyos-authorization': this.contentProtectionConfiguration.integrationParameters['x-keyos-authorization'],
-    };
+    const authorization = this.contentProtectionConfiguration.integrationParameters?.['x-keyos-authorization'];
+    if (authorization !== undefined) {
+      request.headers = {
+        ...request.headers,
+        'x-keyos-authorization': authorization,
+      };
+    }
+
     return request;
   }
 
@@ -42,10 +46,12 @@ export class KeyOSDrmFairplayContentProtectionIntegration implements ContentProt
     }
 
     request.url = this.contentProtectionConfiguration.fairplay?.licenseAcquisitionURL;
-    request.headers = {
-      ...request.headers,
-      'x-keyos-authorization': this.contentProtectionConfiguration.integrationParameters['x-keyos-authorization'],
-    };
+    if (this.contentProtectionConfiguration.integrationParameters !== undefined) {
+      request.headers = {
+        ...request.headers,
+        'x-keyos-authorization': this.contentProtectionConfiguration.integrationParameters['x-keyos-authorization'],
+      };
+    }
     const licenseParameters = `spc=${fromUint8ArrayToBase64String(request.body!)}&assetId=${this.contentId}`;
     request.body = fromStringToUint8Array(licenseParameters);
     return request;

--- a/src/keyos/KeyOSDrmPlayReadyContentProtectionIntegration.ts
+++ b/src/keyos/KeyOSDrmPlayReadyContentProtectionIntegration.ts
@@ -17,10 +17,13 @@ export class KeyOSDrmPlayReadyContentProtectionIntegration implements ContentPro
       throw new Error('The PlayReady KeyOS license url has not been correctly configured.');
     }
     request.url = this.contentProtectionConfiguration.playready?.licenseAcquisitionURL;
-    request.headers = {
-      ...request.headers,
-      'x-keyos-authorization': this.contentProtectionConfiguration.integrationParameters['x-keyos-authorization'],
-    };
+    const authorization = this.contentProtectionConfiguration.integrationParameters?.['x-keyos-authorization'];
+    if (authorization !== undefined) {
+      request.headers = {
+        ...request.headers,
+        'x-keyos-authorization': authorization,
+      };
+    }
     return request;
   }
 }

--- a/src/keyos/KeyOSDrmPlayReadyContentProtectionIntegration.ts
+++ b/src/keyos/KeyOSDrmPlayReadyContentProtectionIntegration.ts
@@ -7,7 +7,7 @@ export class KeyOSDrmPlayReadyContentProtectionIntegration implements ContentPro
 
   constructor(configuration: KeyOSDrmConfiguration) {
     if (!isKeyOSDrmDRMConfiguration(configuration)) {
-      throw new Error('The KeyOS customdata value has not been correctly configured.');
+      throw new Error('Invalid KeyOSDrmConfiguration.');
     }
     this.contentProtectionConfiguration = configuration;
   }

--- a/src/keyos/KeyOSDrmUtils.ts
+++ b/src/keyos/KeyOSDrmUtils.ts
@@ -1,5 +1,5 @@
 import { KeyOSDrmConfiguration } from './KeyOSDrmConfiguration';
 
 export function isKeyOSDrmDRMConfiguration(configuration: KeyOSDrmConfiguration): boolean {
-  return configuration.integrationParameters['x-keyos-authorization'] !== undefined;
+  return configuration.integrationParameters === undefined || configuration.integrationParameters['x-keyos-authorization'] !== undefined;
 }

--- a/src/keyos/KeyOSDrmUtils.ts
+++ b/src/keyos/KeyOSDrmUtils.ts
@@ -1,5 +1,5 @@
 import { KeyOSDrmConfiguration } from './KeyOSDrmConfiguration';
 
 export function isKeyOSDrmDRMConfiguration(configuration: KeyOSDrmConfiguration): boolean {
-  return configuration.integrationParameters === undefined || configuration.integrationParameters['x-keyos-authorization'] !== undefined;
+  return configuration.integration === 'keyos_buydrm';
 }

--- a/src/keyos/KeyOSDrmWidevineContentProtectionIntegration.ts
+++ b/src/keyos/KeyOSDrmWidevineContentProtectionIntegration.ts
@@ -17,10 +17,13 @@ export class KeyOSDrmWidevineContentProtectionIntegration implements ContentProt
       throw new Error('The Widevine KeyOS license url has not been correctly configured.');
     }
     request.url = this.contentProtectionConfiguration.widevine?.licenseAcquisitionURL;
-    request.headers = {
-      ...request.headers,
-      'x-keyos-authorization': this.contentProtectionConfiguration.integrationParameters['x-keyos-authorization'],
-    };
+    const authorization = this.contentProtectionConfiguration.integrationParameters?.['x-keyos-authorization'];
+    if (authorization !== undefined) {
+      request.headers = {
+        ...request.headers,
+        'x-keyos-authorization': authorization,
+      };
+    }
     return request;
   }
 }

--- a/src/keyos/KeyOSDrmWidevineContentProtectionIntegration.ts
+++ b/src/keyos/KeyOSDrmWidevineContentProtectionIntegration.ts
@@ -7,7 +7,7 @@ export class KeyOSDrmWidevineContentProtectionIntegration implements ContentProt
 
   constructor(configuration: KeyOSDrmConfiguration) {
     if (!isKeyOSDrmDRMConfiguration(configuration)) {
-      throw new Error('The KeyOS token has not been correctly configured.');
+      throw new Error('Invalid KeyOSDrmConfiguration.');
     }
     this.contentProtectionConfiguration = configuration;
   }


### PR DESCRIPTION
According to BuyDRM: https://buydrm.com/services-solutions/multikey-service/
>Another API is available for the delivery of a DRM license to the playback platform via authentication .xml provided directly from the player to our License Key Gateway **or via a proxy hosted in the customers own network or premises**.

So the `x-keyos-authorization` header is not mandatory for some THEOplayer users.

